### PR TITLE
Make tests run with TZ=America/Los_Angeles by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "jest",
-    "coverage": "jest --coverage",
+    "test": "TZ=America/Los_Angeles jest",
+    "test:local": "jest",
+    "coverage": "TZ=America/Los_Angeles jest --coverage",
     "codecov": "codecov"
   },
   "dependencies": {


### PR DESCRIPTION
I'm in Central European Summer Time, so running `npm test` fails for me on main, as it seems that tests expect the timezone to be `America/Los_Angeles`. This change sets that timezone as default for test runs, and introduces the `test:local` target that can be executed to run tests with local timezone.