### PR TITLE
Add allowExternalAttendees setting to +5m feature

### DIFF
--- a/src/checks/check-plus-5m.ts
+++ b/src/checks/check-plus-5m.ts
@@ -17,6 +17,7 @@ export namespace CheckPlus5m {
   export type Settings = {
     oneOnOnes: boolean;
     anyEventIOrganizeOrCreateWithAttendees: boolean;
+    allowExternalAttendees: boolean;
     // anyEventWithFiveOrFewerPeopleAndNoEmailListAttendees: boolean;
   };
   export const OPT_OUT: string = "[opt_out_plus5m]";
@@ -104,6 +105,14 @@ export namespace CheckPlus5m {
 
     if (event.description?.includes(CheckPlus5m.OPT_OUT)) {
       Log.log(`👎 skipping, has opt out`);
+      return undefined;
+    }
+
+    if (
+      !settings.allowExternalAttendees &&
+      !EventUtil.doAllAttendeesHaveSameBusinessEmailDomain(event.attendees)
+    ) {
+      Log.log(`👎 skipping, has external attendees`);
       return undefined;
     }
 

--- a/src/checks/user-settings.ts
+++ b/src/checks/user-settings.ts
@@ -24,6 +24,7 @@ export namespace UserSettings {
       plusFiveMinutes: {
         oneOnOnes: boolean;
         anyEventIOrganizeOrCreateWithAttendees: boolean;
+        allowExternalAttendees: boolean;
       };
     };
     teamCalendar: {
@@ -101,6 +102,7 @@ export namespace UserSettings {
         plusFiveMinutes: {
           oneOnOnes: false,
           anyEventIOrganizeOrCreateWithAttendees: false,
+          allowExternalAttendees: false,
           // anyEventWithFiveOrFewerPeopleAndNoEmailListAttendees: false,
         },
       },

--- a/src/webapp/Index.html
+++ b/src/webapp/Index.html
@@ -497,6 +497,22 @@
                   calendar holds)
                 </label>
               </div>
+              <div class="form-check mb-1">
+                <input
+                  class="form-check-input"
+                  type="checkbox"
+                  id="plusFiveMinutesAllowExternal"
+                  v-model="settings.checkSettings.plusFiveMinutes.allowExternalAttendees"
+                  @change="onSettingsChanged"
+                />
+                <label class="form-check-label" for="plusFiveMinutesAllowExternal">
+                  Allow for meetings with external attendees
+                </label>
+                <div class="form-text">
+                  If unchecked, meetings with attendees outside your company will
+                  not be shifted +5m.
+                </div>
+              </div>
             </div>
             <!-- Event Color Setting -->
             <div
@@ -880,6 +896,7 @@
           plusFiveMinutes: {
             oneOnOnes: false,
             anyEventIOrganizeOrCreateWithAttendees: false,
+            allowExternalAttendees: false,
           },
         },
         teamCalendar: {

--- a/test/checks/check-plus-5m.test.ts
+++ b/test/checks/check-plus-5m.test.ts
@@ -10,6 +10,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     settings = {
       oneOnOnes: true,
       anyEventIOrganizeOrCreateWithAttendees: false,
+      allowExternalAttendees: true,
     };
   });
 
@@ -209,6 +210,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     const customSettings = {
       oneOnOnes: false,
       anyEventIOrganizeOrCreateWithAttendees: true,
+      allowExternalAttendees: true,
     };
     const modifiedEvent = {
       ...myOneOnOneEvent,
@@ -238,6 +240,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     const customSettings = {
       oneOnOnes: false,
       anyEventIOrganizeOrCreateWithAttendees: true,
+      allowExternalAttendees: true,
     };
     const modifiedEvent = {
       ...myOneOnOneEvent,
@@ -268,6 +271,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     const customSettings = {
       oneOnOnes: false,
       anyEventIOrganizeOrCreateWithAttendees: true,
+      allowExternalAttendees: true,
     };
     const modifiedEvent = {
       ...myOneOnOneEvent,
@@ -297,6 +301,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     const customSettings = {
       oneOnOnes: false,
       anyEventIOrganizeOrCreateWithAttendees: true,
+      allowExternalAttendees: true,
     };
     const modifiedEvent = {
       ...myOneOnOneEvent,
@@ -326,6 +331,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     const customSettings = {
       oneOnOnes: false,
       anyEventIOrganizeOrCreateWithAttendees: true,
+      allowExternalAttendees: true,
     };
     const modifiedEvent = {
       ...myOneOnOneEvent,
@@ -355,6 +361,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     const customSettings = {
       oneOnOnes: false,
       anyEventIOrganizeOrCreateWithAttendees: true,
+      allowExternalAttendees: true,
     };
     expect(
       CheckPlus5m.checkShouldModifyEvent(theirOOOAllDayEvent, customSettings)
@@ -365,6 +372,7 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     const customSettings = {
       oneOnOnes: false,
       anyEventIOrganizeOrCreateWithAttendees: true,
+      allowExternalAttendees: true,
     };
     expect(CheckPlus5m.checkShouldModifyEvent(holdEvent, customSettings)).toBe(
       undefined
@@ -384,6 +392,90 @@ describe("CheckPlus5m.checkShouldModifyEvent", () => {
     expect(CheckPlus5m.checkShouldModifyEvent(modifiedEvent, settings)).toBe(
       undefined
     );
+  });
+
+  test("should return undefined for an event with external attendees when allowExternalAttendees is false", () => {
+    const customSettings = {
+      oneOnOnes: true,
+      anyEventIOrganizeOrCreateWithAttendees: false,
+      allowExternalAttendees: false,
+    };
+    const modifiedEvent = {
+      ...myOneOnOneEvent,
+      start: {
+        ...myOneOnOneEvent.start,
+        dateTime: "2024-07-26T14:00:00-07:00",
+      },
+      end: { ...myOneOnOneEvent.end, dateTime: "2024-07-26T14:30:00-07:00" },
+      attendees: [
+        {
+          responseStatus: "accepted",
+          self: true,
+          organizer: true,
+          email: "john.doe@block.xyz",
+        },
+        { email: "external@gmail.com", responseStatus: "needsAction" },
+      ],
+    };
+    expect(
+      CheckPlus5m.checkShouldModifyEvent(modifiedEvent, customSettings)
+    ).toBe(undefined);
+  });
+
+  test("should return YES for an event with external attendees when allowExternalAttendees is true", () => {
+    const customSettings = {
+      oneOnOnes: true,
+      anyEventIOrganizeOrCreateWithAttendees: false,
+      allowExternalAttendees: true,
+    };
+    const modifiedEvent = {
+      ...myOneOnOneEvent,
+      start: {
+        ...myOneOnOneEvent.start,
+        dateTime: "2024-07-26T14:00:00-07:00",
+      },
+      end: { ...myOneOnOneEvent.end, dateTime: "2024-07-26T14:30:00-07:00" },
+      attendees: [
+        {
+          responseStatus: "accepted",
+          self: true,
+          organizer: true,
+          email: "john.doe@block.xyz",
+        },
+        { email: "external@gmail.com", responseStatus: "needsAction" },
+      ],
+    };
+    expect(
+      CheckPlus5m.checkShouldModifyEvent(modifiedEvent, customSettings)
+    ).toBe(CheckTypes.ModificationType.YES_ADD_LABEL);
+  });
+
+  test("should return YES for an internal-only event when allowExternalAttendees is false", () => {
+    const customSettings = {
+      oneOnOnes: true,
+      anyEventIOrganizeOrCreateWithAttendees: false,
+      allowExternalAttendees: false,
+    };
+    const modifiedEvent = {
+      ...myOneOnOneEvent,
+      start: {
+        ...myOneOnOneEvent.start,
+        dateTime: "2024-07-26T14:00:00-07:00",
+      },
+      end: { ...myOneOnOneEvent.end, dateTime: "2024-07-26T14:30:00-07:00" },
+      attendees: [
+        {
+          responseStatus: "accepted",
+          self: true,
+          organizer: true,
+          email: "john.doe@block.xyz",
+        },
+        { email: "jane.doe@squareup.com", responseStatus: "needsAction" },
+      ],
+    };
+    expect(
+      CheckPlus5m.checkShouldModifyEvent(modifiedEvent, customSettings)
+    ).toBe(CheckTypes.ModificationType.YES_ADD_LABEL);
   });
 });
 

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -72,6 +72,7 @@ describe("checkEvents", () => {
       plusFiveMinutes: {
         oneOnOnes: true,
         anyEventIOrganizeOrCreateWithAttendees: true,
+        allowExternalAttendees: true,
       },
     },
     teamCalendar: {


### PR DESCRIPTION
## Summary
- Adds a new `allowExternalAttendees` setting under the "Start meetings +5m" feature
- When unchecked (default), meetings with external attendees (non-Block email domains) are not shifted +5m
- Reuses existing `doAllAttendeesHaveSameBusinessEmailDomain()` logic from `event-util.ts`
- Adds UI toggle in the webapp settings page with helper text

## Test plan
- [x] 3 new unit tests covering external attendees blocked, allowed, and internal-only events
- [x] All 249 tests pass (17 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)